### PR TITLE
Add type and id to script tag

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ module.exports = {
     var wid = config.APP.INSPECTLET_WID;
 
     if (wid != null && type === 'head') {
-      return "<script>\n" +
+      return "<script type='text/javascript' id='inspectletjs'>\n" +
         "window.__insp = window.__insp || [];\n" +
         "__insp.push(['wid', " + wid + "]);\n" +
         "(function() {\n" +


### PR DESCRIPTION
The current script tag recommended by inspectlet contains an ID and the type specified.

I don't think it makes too much difference but I think it is interesting to keep the script tag as close as possible of what is recommended by inspectlet =D
