### PR TITLE
Added new INSPECTLET_JS_SERVER and INSPECTLET_JS_URI settings

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,14 +5,16 @@ module.exports = {
   name: 'ember-cli-inspectlet',
 
   contentFor: function(type, config) {
-    var wid = config.APP.INSPECTLET_WID;
+    const wid = config.APP.INSPECTLET_WID;
+    const js_server = config.APP.INSPECTLET_JS_SERVER ? config.APP.INSPECTLET_JS_SERVER : 'cdn.inspectlet.com';
+    const js_uri = config.APP.INSPECTLET_JS_URI ? config.APP.INSPECTLET_JS_URI : 'inspectlet.js';
 
     if (wid != null && type === 'head') {
       return "<script type='text/javascript' id='inspectletjs'>\n" +
         "window.__insp = window.__insp || [];\n" +
         "__insp.push(['wid', " + wid + "]);\n" +
         "(function() {\n" +
-        "function ldinsp(){if(typeof window.__inspld != 'undefined') return; window.__inspld = 1; var insp = document.createElement('script'); insp.type = 'text/javascript'; insp.async = true; insp.id = 'inspsync'; insp.src = ('https:' == document.location.protocol ? 'https' : 'http') + '://cdn.inspectlet.com/inspectlet.js'; var x = document.getElementsByTagName('script')[0]; x.parentNode.insertBefore(insp, x); };\n" +
+        "function ldinsp(){if(typeof window.__inspld != 'undefined') return; window.__inspld = 1; var insp = document.createElement('script'); insp.type = 'text/javascript'; insp.async = true; insp.id = 'inspsync'; insp.src = ('https:' == document.location.protocol ? 'https' : 'http') + '://" + js_server + "/" + js_uri + "'; var x = document.getElementsByTagName('script')[0]; x.parentNode.insertBefore(insp, x); };\n" +
         " setTimeout(ldinsp, 500); document.readyState != 'complete' ? (window.attachEvent ? window.attachEvent('onload', ldinsp) : window.addEventListener('load', ldinsp, false)) : ldinsp();\n" +
         "})();" +
         "</script>"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-cli-inspectlet",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Injects inspectlet scripts into your Ember CLI app.",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
These allow you to configure where you want to load `inspectlet.js` from.
I use inspectlet on my beta site, and often I get freelancers to test my
features before deploying them to prod. The problem is, I can never be
assured that the freelancer isn't running an Ad Blocker extension which
blocks Inspectlet.

Using these new configuraiton settings I can have a version of the
inspectlet.js file loaded from my own domain, thus the Ad Blocker will
not block it.

Example:

```
    ENV.APP.INSPECTLET_WID = '123456';
    ENV.APP.INSPECTLET_JS_SERVER = 'beta.example.com';
    ENV.APP.INSPECTLET_JS_URI = 'assets/js/custom-inspectlet.js';
```